### PR TITLE
Typo in Setup.sh

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -1,5 +1,5 @@
 cd ./six
-sudo pyhton setup.py install
+sudo python setup.py install
 cd ..
 cd ./base58
 sudo python setup.py install


### PR DESCRIPTION
https://github.com/jujugoboom/Bitduino/blob/1a978d13baed14dfcb5dc239d480797a3c6a26d0/Setup.sh#L2

```diff
- sudo pyhton setup.py install
+ sudo python setup.py install
```